### PR TITLE
Add repeat direction

### DIFF
--- a/grafana_dashboards/components/panels.py
+++ b/grafana_dashboards/components/panels.py
@@ -35,7 +35,7 @@ class PanelsItemBase(JsonGenerator):
 class Graph(PanelsItemBase):
 
     _copy_fields = {'stack', 'fill', 'aliasColors', 'leftYAxisLabel', 'bars', 'lines', 'linewidth', 'y_formats',
-                    'x-axis', 'y-axis', 'points', 'pointradius', 'percentage', 'steppedLine', 'repeat',
+                    'x-axis', 'y-axis', 'points', 'pointradius', 'percentage', 'steppedLine', 'repeat', 'repeatDirection',
                     'decimals', 'minSpan', 'datasource', 'description'}
 
     def gen_json_from_data(self, data, context):
@@ -107,7 +107,7 @@ class SingleStat(PanelsItemBase):
 
     _copy_fields = {'prefix', 'postfix', 'nullText', 'format', 'thresholds', 'colorValue', 'colorBackground',
                     'colors', 'prefixFontSize', 'valueFontSize', 'postfixFontSize', 'maxDataPoints', 'datasource',
-                    'repeat', 'decimals', 'minSpan', 'description'}
+                    'repeat', 'repeatDirection', 'decimals', 'minSpan', 'description'}
 
     def gen_json_from_data(self, data, context):
         panel_json = super(SingleStat, self).gen_json_from_data(data, context)

--- a/tests/grafana_dashboards/components/graph/full.json
+++ b/tests/grafana_dashboards/components/graph/full.json
@@ -68,6 +68,7 @@
   ],
   "minSpan": 3,
   "repeat": "node",
+  "repeatDirection": "v",
   "datasource": "datasource",
   "description": "description"
 }

--- a/tests/grafana_dashboards/components/graph/full.yaml
+++ b/tests/grafana_dashboards/components/graph/full.yaml
@@ -62,5 +62,6 @@ graph:
         points: true
   minSpan: 3
   repeat: node
+  repeatDirection: v
   datasource: datasource
   description: description

--- a/tests/grafana_dashboards/components/single-stat/full.json
+++ b/tests/grafana_dashboards/components/single-stat/full.json
@@ -37,6 +37,7 @@
   ],
   "datasource": "datasource",
   "repeat": "var",
+  "repeatDirection": "v",
   "decimals": 1,
   "minSpan": 2,
   "gauge" : {

--- a/tests/grafana_dashboards/components/single-stat/full.yaml
+++ b/tests/grafana_dashboards/components/single-stat/full.yaml
@@ -30,6 +30,7 @@ single-stat:
   maxDataPoints: 100
   datasource: datasource
   repeat: var
+  repeatDirection: v
   decimals: 1
   minSpan: 2
   gauge:


### PR DESCRIPTION
This PR adds support for repeatDirection property.
Supports only graphs and singlestats. Other panels, at the moment does not support repeat property, so repeatDirection property in this context is not meaningful.